### PR TITLE
Add DepMap combined RNAi dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# PyCharm
+.idea

--- a/cancer_data/processors/depmap.py
+++ b/cancer_data/processors/depmap.py
@@ -275,7 +275,7 @@ class Processors:
 
         df = access.load("depmap_mutations")
 
-        df = df[(df["isCOSMIChotspot"] == True) | (df["isTCGAhotspot"] == True)]
+        df = df[(df["isCOSMIChotspot"] is True) | (df["isTCGAhotspot"] is True)]
 
         # exclude rarely damaged genes
         mut_counts = Counter(df["Hugo_Symbol"])

--- a/cancer_data/processors/depmap.py
+++ b/cancer_data/processors/depmap.py
@@ -163,7 +163,7 @@ class Processors:
 
         # SW527 presents as colorectal in depmap_annotations.
         # Cannot map to known cell line.
-        df = df.drop(columns=['SW527_BREAST'])
+        df = df.drop(columns=["SW527_BREAST"])
 
         df.columns = map(ccle_to_depmap.get, df.columns)
         df.index = df.index.map(parentheses_to_snake)

--- a/cancer_data/processors/depmap.py
+++ b/cancer_data/processors/depmap.py
@@ -141,7 +141,7 @@ class Processors:
     def depmap_combined_rnai(raw_path):
         """
 
-        Process DepMap Combined RNAi sensitivities.
+        Process combined DepMap RNAi sensitivities.
 
         Args:
             raw_path (str): the complete path to the
@@ -149,7 +149,6 @@ class Processors:
 
         Returns:
             Processed DataFrame
-
         """
 
         df = pd.read_csv(raw_path, index_col=0)
@@ -158,6 +157,13 @@ class Processors:
         ccle_to_depmap = dict(
             zip(depmap_annotations["CCLE_Name"], depmap_annotations.index)
         )
+        ccle_to_depmap["AZ521_STOMACH"] = "ACH-001015"
+        ccle_to_depmap["GISTT1_GASTROINTESTINAL_TRACT"] = "ACH-002332"
+        ccle_to_depmap["MB157_BREAST"] = "ACH-000621"
+
+        # SW527 presents as colorectal in depmap_annotations.
+        # Cannot map to known cell line.
+        df = df.drop(columns=['SW527_BREAST'])
 
         df.columns = map(ccle_to_depmap.get, df.columns)
         df.index = df.index.map(parentheses_to_snake)

--- a/cancer_data/processors/depmap.py
+++ b/cancer_data/processors/depmap.py
@@ -138,6 +138,39 @@ class Processors:
         return df
 
     @staticmethod
+    def depmap_combined_rnai(raw_path):
+        """
+
+        Process DepMap Combined RNAi sensitivities.
+
+        Args:
+            raw_path (str): the complete path to the
+                            raw downloaded file
+
+        Returns:
+            Processed DataFrame
+
+        """
+
+        df = pd.read_csv(raw_path, index_col=0)
+
+        depmap_annotations = access.load("depmap_annotations")
+        ccle_to_depmap = dict(
+            zip(depmap_annotations["CCLE_Name"], depmap_annotations.index)
+        )
+
+        df.columns = map(ccle_to_depmap.get, df.columns)
+        df.index = df.index.map(parentheses_to_snake)
+
+        df.columns = df.columns.astype(str)
+        df.index = df.index.astype(str)
+
+        df = df.T
+        df = df.astype(np.float16)
+
+        return df
+
+    @staticmethod
     def depmap_gene_tpm(raw_path):
         """
 

--- a/cancer_data/processors/tcga.py
+++ b/cancer_data/processors/tcga.py
@@ -143,7 +143,7 @@ def tcga_splicing(raw_path, preserve_temp=False):
     columns = pd.read_csv(temp, index_col=0, nrows=0).columns
     col_dtypes = {x: np.float16 for x in columns}
 
-    if prserve_temp:
+    if preserve_temp:
         return columns
 
     merged = pd.read_csv(

--- a/cancer_data/schema.csv
+++ b/cancer_data/schema.csv
@@ -35,6 +35,7 @@ depmap_annotations,primary_dataset,,DepMap cell line sample info,depmap,https://
 avana,primary_dataset,,Avana CRISPR-cas9 sensitivities,depmap,https://ndownloader.figshare.com/files/26261293,https://depmap.org/portal/download/,Achilles_gene_effect.csv,297045498,79b14382fc4c5bbf84ece58d2b68e93e,,
 drive,primary_dataset,depmap_annotations,DRIVE RNAi sensitivities,depmap,https://ndownloader.figshare.com/files/11489693,https://depmap.org/portal/download/,D2_DRIVE_gene_dep_scores.csv,58652780,69b13ed329a027cad2d28166e1af20b0,,
 achilles,primary_dataset,depmap_annotations,Achilles RNAi sensitivities ,depmap,https://ndownloader.figshare.com/files/11489669,https://depmap.org/portal/download/,D2_Achilles_gene_dep_scores.csv,140008254,0a27af7890020e90809fb7b354c8cf94,,
+depmap_combined_rnai,primary_dataset,depmap_annotations,DepMap combined RNAi sensitivities,depmap,https://ndownloader.figshare.com/files/13515395,https://depmap.org/portal/download/,D2_combined_gene_dep_scores.csv,160616970,e82566a48993753c20ea5f480f1867ec,,
 depmap_gene_tpm,primary_dataset,,DepMap gene expression,depmap,https://ndownloader.figshare.com/files/26261476,https://depmap.org/portal/download/,CCLE_expression_v2.csv,427363848,c6006df041acf45e3da1dc36fb267f7b,,
 depmap_mutations,primary_dataset,,DepMap mutation calls,depmap,https://ndownloader.figshare.com/files/26261527,https://depmap.org/portal/download/,CCLE_mutations.csv,262777684,59dc9d81303e2d3063b6fc7e9b0f08f3,,
 depmap_damaging,secondary_dataset,depmap_mutations,Binary DepMap damaging mutation status,depmap,,,,,,,


### PR DESCRIPTION
Hey @kevinhu - I'd like to add support for the DepMap combined RNAi dataset (in addition to `drive` and `achilles`).

Here it is running locally:
```
import cancer_data
cancer_data.download_and_process('depmap_annotations')
sample_info.csv already downloaded and matches provided md5sum.
Processing depmap_annotations
INFO:numexpr.utils:Note: NumExpr detected 12 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
INFO:numexpr.utils:NumExpr defaulting to 8 threads.
/Users/michel/redcell/cancer_data/venv/lib/python3.9/site-packages/tables/filters.py:326: FiltersWarning: compression library ``bzip2`` is not available; using ``zlib`` instead
  warnings.warn("compression library ``%s`` is not available; "
cancer_data.download_and_process('depmap_combined_rnai')
Downloading https://ndownloader.figshare.com/files/13515395
100%|██████████| 161M/161M [00:06<00:00, 23.5MiB/s]
D2_combined_gene_dep_scores.csv matches provided md5sum.
Processing depmap_combined_rnai
/Users/michel/redcell/cancer_data/venv/lib/python3.9/site-packages/tables/filters.py:326: FiltersWarning: compression library ``bzip2`` is not available; using ``zlib`` instead
  warnings.warn("compression library ``%s`` is not available; "
dcr = cancer_data.load('depmap_combined_rnai')
dcr.shape
Out[6]: (712, 17309)
```